### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -7,24 +7,24 @@
 #######################################
 
 
-BWCSentence	    KEYWORD1
-Sentence	    KEYWORD1
-RMCSentence	    KEYWORD1
-WPLSentence	    KEYWORD1
-MessageBus      KEYWORD1
-Instrument      KEYWORD1
-Point           KEYWORD1
-StreamTalker    KEYWORD1
-CourseComputer  KEYWORD1
+BWCSentence	KEYWORD1
+Sentence	KEYWORD1
+RMCSentence	KEYWORD1
+WPLSentence	KEYWORD1
+MessageBus	KEYWORD1
+Instrument	KEYWORD1
+Point	KEYWORD1
+StreamTalker	KEYWORD1
+CourseComputer	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-getMessage	    KEYWORD2
-putMessage    	KEYWORD2
-subscribe    	KEYWORD2
-broadcast       KEYWORD2
-addFilter       KEYWORD2
+getMessage	KEYWORD2
+putMessage	KEYWORD2
+subscribe	KEYWORD2
+broadcast	KEYWORD2
+addFilter	KEYWORD2
 
 ######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords